### PR TITLE
Async reading for all test files

### DIFF
--- a/app/src/Widget.css
+++ b/app/src/Widget.css
@@ -48,6 +48,15 @@
     color: #FFFFFF;
 }
 
+.section.duration {
+    background-color: #9e9e9e;
+    color: #FFFFFF;
+}
+
+.section.failed-tests hr {
+    border-color: #6e6e6e;
+}
+
 .topbar-text {
     margin: 10px;
     padding: 0;

--- a/app/src/Widget.js
+++ b/app/src/Widget.js
@@ -9,14 +9,14 @@ export default function Widget() {
 
     useEffect(() => {
         // should use this api with jobUUID (otherwise - which xml to use? might as well parse all and add up)
-        // TODO: api does not work yet
         fetch(`/api/all-tests/${jobUuid}`)
             .then(response => response.json())
-            .then(data => setTestsData(data));
+            .then(data => setTestsData(data[0]));
     }, [jobUuid]);
 
     const passed = testsData ? testsData.tests - testsData.failures : 0;
     const failures = testsData ? testsData.failures : 0;
+    const duration = testsData ? testsData.time : 0;
 
     const status = <span className={failures > 0 ? "status-failure" : "status-success"}>
         <i className="feather icon-check-circle"/>&nbsp;{failures > 0 ? failures +" Failures" : "Success"}
@@ -35,6 +35,13 @@ export default function Widget() {
             <h5>Passed</h5>
             <hr />
             <h3 className="status-subtext">{passed}</h3>
+        </div>)
+    }
+    if(duration > 0) {
+        sections.push(<div className="section duration">
+            <h5>Duration</h5>
+            <hr />
+            <h3 className="status-subtext">{duration.toFixed(1)}s</h3>
         </div>)
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,7 +134,7 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                 attributeNamePrefix: "attr_"
             };
             const parser = new XMLParser(options);
-            const response = files.reduce(async (arr, file) => {
+            return files.reduce(async (arr, file) => {
                 try {
                     const data = await fsPromise.readFile(`${dst}/${file.name}`, "utf8");
                     const output = parser.parse(data);
@@ -148,14 +148,13 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                             tests: tests + obj.tests,
                             time: time + obj.time,
                         };
-                    }, { failures: 0, tests: 0, time: 0 });
+                    }, {failures: 0, tests: 0, time: 0});
                     return [...arr, test];
                 } catch (e) {
                     console.log("Failed to read file, ", e);
                     return arr;
                 }
             }, []);
-            return response;
         })
         .then((response) => {
             console.log({ response });

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var expressWs = require('express-ws')(app);
 fs = require('fs');
 let path = require('path');
 const Client = require('ssh2-sftp-client');
+const fsPromise = require("fs").promises;
 
 const FRONT_END_PATH = path.join(__dirname, '..', 'app', 'build')
 const puppeteer = require('puppeteer');
@@ -115,6 +116,7 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
         username: 'root',
         password: 'password'
     };
+
     let sftp = new Client;
     sftp.connect(config)
         .then(() => {
@@ -134,7 +136,7 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
             const parser = new XMLParser(options);
             const responsePromises = files.reduce(async (arr, file) => {
                 try {
-                    const data = await fs.readFile(`${dst}/${file.name}`);
+                    const data = await fsPromise.readFile(`${dst}/${file.name}`, "utf8");
                     const output = parser.parse(data);
                     const test = Object.keys(output.testsuites.testsuite).reduce((obj, key) => {
                         switch (key) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,16 +138,15 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                 try {
                     const data = await fsPromise.readFile(`${dst}/${file.name}`, "utf8");
                     const output = parser.parse(data);
-                    console.log("Test Suite:", output.testsuites.testsuite);
-                    console.log("\n\n\n Value:", output.testsuites.testsuite[0]);
-                    const test = output.testsuites.testsuite.reduce((obj, key) => {
-                        const failures = parseInt(key['attr_failures']) || obj.failures;
-                        const tests = parseInt(key['attr_tests']) || obj.tests;
-                        const time = parseFloat(key['attr_time']) || obj.time;
+                    const testcases = output.testsuites.testsuite || [];
+                    const test = testcases.reduce((obj, key) => {
+                        const failures = parseInt(key['attr_failures']) || 0;
+                        const tests = parseInt(key['attr_tests']) || 0;
+                        const time = parseFloat(key['attr_time']) || 0;
                         return {
-                            failures: failures,
-                            test: tests,
-                            time: time,
+                            failures: failures + obj.failures,
+                            test: tests + obj.tests,
+                            time: time + obj.time,
                         };
                     }, { failures: 0, tests: 0, time: 0 });
                     return [...arr, test];

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,7 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                     return arr;
                 }
             }, []);
-            return Promise.all(responsePromises);
+            return await Promise.all(responsePromises);
         })
         .then((response) => {
             console.log({ response });

--- a/lib/index.js
+++ b/lib/index.js
@@ -136,18 +136,18 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                 try {
                     const data = await fs.readFile(`${dst}/${file.name}`);
                     const output = parser.parse(data);
-                    const test = Object.keys(output).reduce((obj, key) => {
+                    const test = Object.keys(output.testsuites.testsuite).reduce((obj, key) => {
                         switch (key) {
                             case "attr_failures": {
-                                obj.failures = parseInt(test.attr_failures);
+                                obj.failures = parseInt(key['attr_failures']);
                                 break;
                             }
                             case "attr_tests": {
-                                obj.tests = parseInt(test.attr_tests);
+                                obj.tests = parseInt(key['attr_tests']);
                                 break;
                             }
                             case "attr_time": {
-                                obj.time = parseFloat(test.attr_time);
+                                obj.time = parseFloat(key['attr_time']);
                                 break;
                             }
                         }
@@ -159,9 +159,10 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                     return arr;
                 }
             }, []);
-            return await Promise.all(responsePromises);
+            return Promise.all(responsePromises);
         })
         .then((response) => {
+            console.log({ response });
             res.send(response);
         })
         .then(() => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,23 +138,15 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                 try {
                     const data = await fsPromise.readFile(`${dst}/${file.name}`, "utf8");
                     const output = parser.parse(data);
-                    console.log({ output });
-                    const test = Object.keys(output.testsuites.testsuite).reduce((obj, key) => {
-                        switch (key) {
-                            case "attr_failures": {
-                                obj.failures = parseInt(key['attr_failures']);
-                                break;
-                            }
-                            case "attr_tests": {
-                                obj.tests = parseInt(key['attr_tests']);
-                                break;
-                            }
-                            case "attr_time": {
-                                obj.time = parseFloat(key['attr_time']);
-                                break;
-                            }
-                        }
-                        return obj;
+                    const test = output.testsuites.testsuite.reduce((obj, key) => {
+                        const failures = parseInt(key['attr_failures']) || obj.failures;
+                        const tests = parseInt(key['attr_tests']) || obj.tests;
+                        const time = parseFloat(key['attr_time']) || obj.time;
+                        return {
+                            failures: failures,
+                            test: tests,
+                            time: time,
+                        };
                     }, { failures: 0, tests: 0, time: 0 });
                     return [...arr, test];
                 } catch (e) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,6 +138,7 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                 try {
                     const data = await fsPromise.readFile(`${dst}/${file.name}`, "utf8");
                     const output = parser.parse(data);
+                    console.log({ output });
                     const test = Object.keys(output.testsuites.testsuite).reduce((obj, key) => {
                         switch (key) {
                             case "attr_failures": {

--- a/lib/index.js
+++ b/lib/index.js
@@ -134,7 +134,7 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                 attributeNamePrefix: "attr_"
             };
             const parser = new XMLParser(options);
-            const responsePromises = files.reduce(async (arr, file) => {
+            const response = files.reduce(async (arr, file) => {
                 try {
                     const data = await fsPromise.readFile(`${dst}/${file.name}`, "utf8");
                     const output = parser.parse(data);
@@ -145,7 +145,7 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                         const time = parseFloat(key['attr_time']) || 0;
                         return {
                             failures: failures + obj.failures,
-                            test: tests + obj.tests,
+                            tests: tests + obj.tests,
                             time: time + obj.time,
                         };
                     }, { failures: 0, tests: 0, time: 0 });
@@ -155,7 +155,7 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                     return arr;
                 }
             }, []);
-            return await Promise.all(responsePromises);
+            return response;
         })
         .then((response) => {
             console.log({ response });
@@ -165,7 +165,7 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
             sftp.end();
         })
         .catch(err => {
-            console.error(err.message);
+            console.error(err, err.message);
         });
 })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,6 +138,8 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                 try {
                     const data = await fsPromise.readFile(`${dst}/${file.name}`, "utf8");
                     const output = parser.parse(data);
+                    console.log("Test Suite:", output.testsuites.testsuite);
+                    console.log("\n\n\n Value:", output.testsuites.testsuite[0]);
                     const test = output.testsuites.testsuite.reduce((obj, key) => {
                         const failures = parseInt(key['attr_failures']) || obj.failures;
                         const tests = parseInt(key['attr_tests']) || obj.tests;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const puppeteer = require('puppeteer');
 const {exec} = require("child_process");
 const {XMLParser} = require("fast-xml-parser");
 const {response} = require("express");
+const { parse } = require('path');
 const STDOUT_STYLE = `
 <style>
 .stdio, pre {
@@ -115,7 +116,6 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
         password: 'password'
     };
     let sftp = new Client;
-    let response = [];
     sftp.connect(config)
         .then(() => {
             return sftp.list(remotePath, re);
@@ -132,26 +132,34 @@ app.get('/api/all-tests/:jobUuid', function(req, res, next){
                 attributeNamePrefix: "attr_"
             };
             const parser = new XMLParser(options);
-            await Promise.all(files.map(async (file) => {
-                await fs.readFile(`${dst}/${file.name}`, (err, data) => {
-                let test = {
-                    failures: 0,
-                    tests: 0,
-                    time: 0,
-                };
-                if (err) {
-                    console.log(`${req.params.fileName} does not exist`);
-                    return
+            const responsePromises = files.reduce(async (arr, file) => {
+                try {
+                    const data = await fs.readFile(`${dst}/${file.name}`);
+                    const output = parser.parse(data);
+                    const test = Object.keys(output).reduce((obj, key) => {
+                        switch (key) {
+                            case "attr_failures": {
+                                obj.failures = parseInt(test.attr_failures);
+                                break;
+                            }
+                            case "attr_tests": {
+                                obj.tests = parseInt(test.attr_tests);
+                                break;
+                            }
+                            case "attr_time": {
+                                obj.time = parseFloat(test.attr_time);
+                                break;
+                            }
+                        }
+                        return obj;
+                    }, { failures: 0, tests: 0, time: 0 });
+                    return [...arr, test];
+                } catch (e) {
+                    console.log("Failed to read file, ", e);
+                    return arr;
                 }
-                const output = parser.parse(data);
-                for (const testsuite of output.testsuites.testsuite) {
-                    test.failures = parseInt(testsuite.attr_failures);
-                    test.tests = parseInt(testsuite.attr_tests);
-                    test.time = parseFloat(testsuite.attr_time);
-                }
-                response.push(test)
-            })}));
-            return response
+            }, []);
+            return await Promise.all(responsePromises);
         })
         .then((response) => {
             res.send(response);


### PR DESCRIPTION
Updating the /all-tests api route to read the test files and return a response with the corresponding failures, tests, and time instead of an empty array

- This uses fs.promises